### PR TITLE
meta - remove Safari-specific pinned tab

### DIFF
--- a/_assets/images/pinned-tab.svg
+++ b/_assets/images/pinned-tab.svg
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<svg x="0px" y="0px" viewBox="0 0 500 500" xml:space="preserve">
-	<path d="M0,250l250,250l250-250L250,0L0,250z"/>
-</svg>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -13,7 +13,6 @@
   <link rel="icon" href="{% asset favicon.ico @path %}">
   <link rel="icon" sizes="128x128" href="{% asset android-icon-sm.png @path %}">
   <link rel="icon" sizes="192x192" href="{% asset android-icon-lg.png @path %}">
-  <link rel="mask-icon" href="{% asset pinned-tab.svg @path %}" color="#ff6767">
   <link rel="apple-touch-icon" href="{% asset touch-icon-iphone-sm.png @path %}">
   <link rel="apple-touch-icon" sizes="152x152" href="{% asset touch-icon-ipad.png @path %}">
   <link rel="apple-touch-icon" sizes="167x167" href="{% asset touch-icon-ipad-pro.png @path %}">


### PR DESCRIPTION
Seems to no longer be a thing… if it ever was?